### PR TITLE
endian.h import fixed in compression.cc on OSX

### DIFF
--- a/compression.cc
+++ b/compression.cc
@@ -292,7 +292,11 @@ private:
   }
 };
 
+#ifdef __APPLE__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 
 // like NoStreamEnDecoder, but also adds the uncompressed size before the stream
 //NOTE You should make sure that the compression function doesn't overwrite any


### PR DESCRIPTION
This fixes an `#include` in `compression.cc` for OSX, similarly to #7.
