### PR TITLE
Add support for compiling on OpenBSD.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Code contributions:
   Igor Katson <igor.katson@gmail.com>
   Eugene Agafonov <e.a.agafonov@gmail.com>
   Antonia Stevens <a@antevens.com>
+  Frank Groeneveld <frank@frankgroeneveld.nl>
 
 Feel free to add yourself to this list in your pull-request.
 Please modify this file instead of source headers.

--- a/unbuffered_file.cc
+++ b/unbuffered_file.cc
@@ -13,7 +13,7 @@
 #include "unbuffered_file.hh"
 
 
-#ifdef __APPLE__
+#if defined( __APPLE__ ) || defined( __OpenBSD__ )
 #define lseek64 lseek
 #endif
 
@@ -24,7 +24,7 @@ UnbufferedFile::UnbufferedFile( char const * fileName, Mode mode )
 
   int flags = ( mode == WriteOnly ? ( O_WRONLY | O_CREAT | O_TRUNC ) :
                                     O_RDONLY );
-#ifndef __APPLE__
+#if !defined( __APPLE__ ) && !defined( __OpenBSD__ )
   flags |= O_LARGEFILE;
 #endif
   fd = open( fileName, flags, 0666 );


### PR DESCRIPTION
Based on changes made to support the BSD based Mac OS X. Only a replacement for sendfile is still needed to completely support it. Could somebody advise on how to safely write it with read/write calls?
I've disabled the sendfile fall-back on OpenBSD for now.