### PR TITLE
Add missing endian macros on OS X

### DIFF
--- a/compression.cc
+++ b/compression.cc
@@ -5,6 +5,7 @@
 
 #include "compression.hh"
 #include "check.hh"
+#include "endian.hh"
 
 namespace Compression {
 

--- a/endian.hh
+++ b/endian.hh
@@ -6,9 +6,27 @@
 
 #include <stdint.h>
 #include <arpa/inet.h>
+
 #ifdef __APPLE__
 #include <machine/endian.h>
-#else
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#else // __APPLE__
 #include <endian.h>
 #endif
 


### PR DESCRIPTION
Mac OS X (Yosemite) doesn't have the endian macros natively. Here I added them based on this:

https://gist.github.com/yinyin/2027912