### PR TITLE
Use same rename method on all platforms and make file.cc more readable.

### DIFF
--- a/file.cc
+++ b/file.cc
@@ -6,11 +6,6 @@
 #include <unistd.h>
 #include <cerrno>
 #include <cstring>
-#if defined( __APPLE__ ) || defined( __OpenBSD__ )
-  #include <sys/socket.h>
-#else
-  #include <sys/sendfile.h>
-#endif
 #include <sys/types.h>
 #include <fcntl.h>
 
@@ -55,7 +50,8 @@ void File::rename( std::string const & from,
       int read_fd;
       int write_fd;
       struct stat stat_buf;
-      off_t offset = 0;
+      size_t BUFSIZE = 4096, size;
+      char buf[BUFSIZE];
 
       /* Open the input file. */
       read_fd = ::open( from.c_str(), O_RDONLY );
@@ -65,24 +61,12 @@ void File::rename( std::string const & from,
        source file. */
       write_fd = ::open( to.c_str(), O_WRONLY | O_CREAT, stat_buf.st_mode );
       /* Blast the bytes from one file to the other. */
-      #if defined( __APPLE__ )
-      if ( -1 == sendfile(write_fd, read_fd, offset, &stat_buf.st_size, NULL, 0) )
-         throw exCantRename( from + " to " + to );
-      #elif defined( __OpenBSD__ )
-
-      size_t BUFSIZE = 4096, size;
-      char buf[BUFSIZE];
 
       while ( ( size = ::read( read_fd, buf, BUFSIZE ) ) != -1 && size != 0 )
         ::write( write_fd, buf, size );
 
       if ( size == -1 )
          throw exCantRename( from + " to " + to );
-
-      #else
-      if ( -1 == sendfile(write_fd, read_fd, &offset, stat_buf.st_size) )
-         throw exCantRename( from + " to " + to );
-      #endif
 
       /* Close up. */
       ::close( read_fd );


### PR DESCRIPTION
I propose to use the read/write loop on all platforms, because it makes file.cc a lot more readable (without all the ifdef and endif statements) and the performance gain of using sendfile is small, see for example: https://stackoverflow.com/questions/10195343/copy-a-file-in-an-sane-safe-and-efficient-way