### PR TITLE
Improve backup performance by initializing CodedOutputStream only once

### DIFF
--- a/backup_creator.cc
+++ b/backup_creator.cc
@@ -22,7 +22,7 @@ BackupCreator::BackupCreator( Config const & config,
   chunkIndex( chunkIndex ), chunkStorageWriter( chunkStorageWriter ),
   ringBufferFill( 0 ),
   chunkToSaveFill( 0 ),
-  backupDataStream( new google::protobuf::io::StringOutputStream( &backupData ) ),
+  backupDataStream( new google::protobuf::io::CodedOutputStream( new google::protobuf::io::StringOutputStream( &backupData ) ) ),
   chunkIdGenerated( false )
 {
   // In our ring buffer we have enough space to store one chunk plus an extra

--- a/backup_creator.hh
+++ b/backup_creator.hh
@@ -49,7 +49,8 @@ class BackupCreator: ChunkIndex::ChunkInfoInterface, NoCopy
   RollingHash rollingHash;
 
   string backupData;
-  sptr< google::protobuf::io::StringOutputStream > backupDataStream;
+
+  sptr< google::protobuf::io::CodedOutputStream > backupDataStream;
 
   /// Sees if the current block in the ring buffer exists in the chunk store.
   /// If it does, the reference is emitted and the ring buffer is cleared


### PR DESCRIPTION
Right now, for every emitted instruction, we call `Message::serialize` with our `StringOutputStream`, which results in the allocation of a new `CodedOutputStream` in `message.cc`. This causes massive slowness.

I believe the root cause is https://code.google.com/p/protobuf/source/browse/trunk/src/google/protobuf/io/coded_stream.cc?r=417#541 -- CodedOutputStream clearly expects to be kind of long-lived.

This simple patch changes BackupCreator to create a CodedOutputStream only once, at the start. Since we use `sptr::reset` before returning the backup data to the user, we correctly clean up the CodedOutputStream and therefore flush the buffer.

This is likely only visible when backing up data that's almost fully deduplicated, since otherwise LZMA etc. overshadow this in `perf`. A first non-scientific test raised my backup speed on a rusty Atom CPU from 1MB/s to 20MB/s, now maxing out the disk.
