### PR TITLE
Added support for FreeBSD: fixed many compile errors to allow for

### DIFF
--- a/backup_collector.hh
+++ b/backup_collector.hh
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include <unistd.h>
 
 #include "bundle.hh"
 #include "chunk_index.hh"

--- a/compression.cc
+++ b/compression.cc
@@ -314,6 +314,8 @@ private:
 
 #ifdef __APPLE__
 #include <machine/endian.h>
+#elif __FreeBSD__
+#include <sys/endian.h>
 #else
 #include <endian.h>
 #endif

--- a/endian.hh
+++ b/endian.hh
@@ -25,8 +25,12 @@
 #define htole64(x) OSSwapHostToLittleInt64(x)
 #define be64toh(x) OSSwapBigToHostInt64(x)
 #define le64toh(x) OSSwapLittleToHostInt64(x)
+//__APPLE__
 
-#else // __APPLE__
+#elif __FreeBSD__
+#include <sys/endian.h>
+
+#else
 #include <endian.h>
 #endif
 

--- a/file.cc
+++ b/file.cc
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <cerrno>
 #include <cstring>
-#if defined( __APPLE__ ) || defined( __OpenBSD__ )
+#if defined( __APPLE__ ) || defined( __OpenBSD__ ) || defined(__FreeBSD__)
   #include <sys/socket.h>
 #else
   #include <sys/sendfile.h>
@@ -70,7 +70,7 @@ void File::rename( std::string const & from,
       #if defined( __APPLE__ )
       if ( -1 == sendfile( write_fd, read_fd, offset, &stat_buf.st_size, NULL, 0 ) )
          throw exCantRename( from + " to " + to );
-      #elif defined( __OpenBSD__ )
+      #elif defined( __OpenBSD__ ) || defined(__FreeBSD__)
 
       size_t BUFSIZE = 4096, size;
       char buf[BUFSIZE];

--- a/unbuffered_file.cc
+++ b/unbuffered_file.cc
@@ -13,7 +13,7 @@
 #include "unbuffered_file.hh"
 
 
-#if defined( __APPLE__ ) || defined( __OpenBSD__ )
+#if defined( __APPLE__ ) || defined( __OpenBSD__ ) || defined(__FreeBSD__)
 #define lseek64 lseek
 #endif
 
@@ -24,7 +24,7 @@ UnbufferedFile::UnbufferedFile( char const * fileName, Mode mode )
 
   int flags = ( mode == WriteOnly ? ( O_WRONLY | O_CREAT | O_TRUNC ) :
                                     O_RDONLY );
-#if !defined( __APPLE__ ) && !defined( __OpenBSD__ )
+#if !defined( __APPLE__ ) && !defined( __OpenBSD__ ) && !defined(__FreeBSD__)
   flags |= O_LARGEFILE;
 #endif
   fd = open( fileName, flags, 0666 );

--- a/zbackup_base.cc
+++ b/zbackup_base.cc
@@ -3,6 +3,8 @@
 
 #include <sys/wait.h>
 #include <cerrno>
+#include <unistd.h>
+#include <signal.h>
 
 #include "zbackup_base.hh"
 

--- a/zutils.cc
+++ b/zutils.cc
@@ -5,6 +5,7 @@
 #include "backup_creator.hh"
 #include "sha256.hh"
 #include "backup_collector.hh"
+#include <unistd.h>
 
 using std::vector;
 using std::bitset;


### PR DESCRIPTION
compiling on FreeBSD 10.1 (PC-BSD). Some items wrapped in ifdefs, others
not; so may want to test compile on Linux.

I haven't tested on Linux, to see if the unwrapped, added includes might mess anything up. But maybe the #ifndef -> #define in the headers will take care of that, if they've been introduced elsewhere.