### PR TITLE
Corrected the umask setting for temporary file creation.

### DIFF
--- a/tmp_mgr.cc
+++ b/tmp_mgr.cc
@@ -44,8 +44,13 @@ sptr< TemporaryFile > TmpMgr::makeTemporaryFile()
 {
   string name( Dir::addPath( path, "XXXXXX") );
 
-  umask( S_IRUSR | S_IWUSR | S_IRGRP );
+  // Set the umask to remove permisions of grp and other
+  // in case an insecure (older) mkstemp is used.
+  mode_t old_mask = umask( S_IRWXG | S_IRWXO );
+  // Create the temporary file.
   int fd = mkstemp( &name[ 0 ] );
+  // Reset the umask to the previous setting
+  umask(old_mask);
 
   if ( fd == -1 || close( fd ) != 0 )
     throw exCantCreate( path );


### PR DESCRIPTION
Added reset to old umask, afterwards.

Perhaps explicitly setting the file mode, after the file is created
(before potentially sensitive data is written to the file.), could be
done, instead of using umask.
e.g.
fchmod(fd2, S_IRUSR | S_IWUSR );