### PR TITLE
Experimental: "cacheless restore" using a seekable stream

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ Code contributions:
   Benjamin Koch <bbbsnowball@gmail.com>
   Gleb Golubitsky <sectoid@gnolltech.org>
   Igor Katson <igor.katson@gmail.com>
+  Vitaliy Filippov <vitalif@yourcmc.ru>
   Eugene Agafonov <e.a.agafonov@gmail.com>
   Antonia Stevens <a@antevens.com>
   Frank Groeneveld <frank@frankgroeneveld.nl>

--- a/backup_collector.cc
+++ b/backup_collector.cc
@@ -38,7 +38,7 @@ void BundleCollector::startBundle( Bundle::Id const & bundleId )
   usedChunks = 0;
 }
 
-void BundleCollector::processChunk( ChunkId const & chunkId )
+void BundleCollector::processChunk( ChunkId const & chunkId, uint32_t size )
 {
   if ( gcDeep )
   {

--- a/backup_collector.hh
+++ b/backup_collector.hh
@@ -40,7 +40,7 @@ public:
 
   void startBundle( Bundle::Id const & bundleId );
 
-  void processChunk( ChunkId const & chunkId );
+  void processChunk( ChunkId const & chunkId, uint32_t size );
 
   void finishBundle( Bundle::Id const & bundleId, BundleInfo const & info );
 

--- a/chunk_index.hh
+++ b/chunk_index.hh
@@ -49,7 +49,7 @@ class IndexProcessor
 public:
   virtual void startIndex( string const & ) = 0;
   virtual void startBundle( Bundle::Id const & ) = 0;
-  virtual void processChunk( ChunkId const & ) = 0;
+  virtual void processChunk( ChunkId const &, uint32_t ) = 0;
   virtual void finishBundle( Bundle::Id const &, BundleInfo const & ) = 0;
   virtual void finishIndex( string const & ) = 0;
 };
@@ -61,10 +61,11 @@ class ChunkIndex: NoCopy, IndexProcessor
   struct Chain
   {
     ChunkId::CryptoHashPart cryptoHash;
+    uint32_t size;
     Chain * next;
     Bundle::Id const * bundleId;
 
-    Chain( ChunkId const &, Bundle::Id const * bundleId );
+    Chain( ChunkId const &, uint32_t, Bundle::Id const * bundleId );
 
     bool equalsTo( ChunkId const & id );
   };
@@ -100,18 +101,18 @@ public:
 
   /// If the given chunk exists, its bundle id is returned, otherwise NULL
   Bundle::Id const * findChunk( ChunkId::RollingHashPart,
-                                ChunkInfoInterface & );
+                                ChunkInfoInterface &, uint32_t *size = NULL );
 
   /// If the given chunk exists, its bundle id is returned, otherwise NULL
-  Bundle::Id const * findChunk( ChunkId const & );
+  Bundle::Id const * findChunk( ChunkId const &, uint32_t *size = NULL );
 
   /// Adds a new chunk to the index if it did not exist already. Returns true
   /// if added, false if existed already
-  bool addChunk( ChunkId const &, Bundle::Id const & );
+  bool addChunk( ChunkId const &, uint32_t, Bundle::Id const & );
 
   void startIndex( string const & );
   void startBundle( Bundle::Id const & );
-  void processChunk( ChunkId const & );
+  void processChunk( ChunkId const &, uint32_t );
   void finishBundle( Bundle::Id const &, BundleInfo const & );
   void finishIndex( string const & );
 
@@ -120,7 +121,7 @@ public:
 private:
   /// Inserts new chunk id into the in-memory hash table. Returns the created
   /// Chain if it was inserted, NULL if it existed before
-  Chain * registerNewChunkId( ChunkId const & id, Bundle::Id const * );
+  Chain * registerNewChunkId( ChunkId const & id, uint32_t, Bundle::Id const * );
 };
 
 #endif

--- a/chunk_storage.cc
+++ b/chunk_storage.cc
@@ -30,7 +30,7 @@ Writer::~Writer()
 
 bool Writer::add( ChunkId const & id, void const * data, size_t size )
 {
-  if ( index.addChunk( id, getCurrentBundleId() ) )
+  if ( index.addChunk( id, size, getCurrentBundleId() ) )
   {
     // Added to the index? Emit to the bundle then
     if ( getCurrentBundle().getPayloadSize() + size >
@@ -209,6 +209,22 @@ Reader::Reader( Config const & configIn,
 {
   verbosePrintf( "Using up to %zu MB of RAM as cache\n",
                  maxCacheSizeBytes / 1048576 );
+}
+
+Bundle::Id const * Reader::getBundleId( ChunkId const & chunkId, size_t & size )
+{
+  uint32_t s;
+  if ( Bundle::Id const * bundleId = index.findChunk( chunkId, &s ) )
+  {
+    size = s;
+    return bundleId;
+  }
+  else
+  {
+    string blob = chunkId.toBlob();
+    throw exNoSuchChunk( toHex( ( unsigned char const * ) blob.data(),
+                                blob.size() ) );
+  }
 }
 
 void Reader::get( ChunkId const & chunkId, string & data, size_t & size )

--- a/chunk_storage.hh
+++ b/chunk_storage.hh
@@ -124,6 +124,8 @@ public:
   Reader( Config const &, EncryptionKey const &, ChunkIndex & index,
           string const & bundlesDir, size_t maxCacheSizeBytes );
 
+  Bundle::Id const * getBundleId( ChunkId const &, size_t & size );
+
   /// Loads the given chunk from the store into the given buffer. May throw file
   /// and decompression exceptions. 'data' may be enlarged but won't be shrunk.
   /// The size of the actual chunk would be stored in 'size'

--- a/unbuffered_file.cc
+++ b/unbuffered_file.cc
@@ -22,8 +22,8 @@ UnbufferedFile::UnbufferedFile( char const * fileName, Mode mode )
   throw( exCantOpen )
 {
 
-  int flags = ( mode == WriteOnly ? ( O_WRONLY | O_CREAT | O_TRUNC ) :
-                                    O_RDONLY );
+  int flags = ( mode == ReadWrite ? ( O_RDWR | O_CREAT ) :
+     ( mode == WriteOnly ? ( O_WRONLY | O_CREAT | O_TRUNC ) : O_RDONLY ) );
 #if !defined( __APPLE__ ) && !defined( __OpenBSD__ ) && !defined(__FreeBSD__) && !defined(__CYGWIN__)
   flags |= O_LARGEFILE;
 #endif
@@ -97,6 +97,12 @@ UnbufferedFile::Offset UnbufferedFile::size() throw( exSeekError )
 void UnbufferedFile::seekCur( Offset offset ) throw( exSeekError )
 {
   if ( lseek64( fd, offset, SEEK_CUR ) < 0 )
+    throw exSeekError();
+}
+
+void UnbufferedFile::seek( Offset offset ) throw( exSeekError )
+{
+  if ( lseek64( fd, offset, SEEK_SET ) < 0 )
     throw exSeekError();
 }
 

--- a/unbuffered_file.hh
+++ b/unbuffered_file.hh
@@ -31,7 +31,8 @@ public:
   enum Mode
   {
     ReadOnly,
-    WriteOnly
+    WriteOnly,
+    ReadWrite
   };
 
   typedef int64_t Offset;
@@ -52,6 +53,9 @@ public:
 
   /// Seeks to the given offset, relative to the current file offset
   void seekCur( Offset ) throw( exSeekError );
+
+  /// Seeks to the given offset, relative to the beginning
+  void seek( Offset ) throw( exSeekError );
 
   ~UnbufferedFile() throw();
 

--- a/zbackup.cc
+++ b/zbackup.cc
@@ -166,6 +166,8 @@ invalid_option:
 "    init <storage path> - initializes new storage\n"
 "    backup <backup file name> - performs a backup from stdin\n"
 "    restore <backup file name> - restores a backup to stdout\n"
+"    restore <backup file name> <output file name> -\n"
+"            restores a backup to file using two-pass \"cacheless\" process\n"
 "    export <source storage path> <destination storage path> -\n"
 "            performs export from source to destination storage\n"
 "    import <source storage path> <destination storage path> -\n"
@@ -229,15 +231,18 @@ invalid_option:
     if ( strcmp( args[ 0 ], "restore" ) == 0 )
     {
       // Perform the restore
-      if ( args.size() != 2 )
+      if ( args.size() != 2 && args.size() != 3 )
       {
-        fprintf( stderr, "Usage: %s %s <backup file name>\n",
+        fprintf( stderr, "Usage: %s %s <backup file name> [output file name]\n",
                  *argv , args[ 0 ] );
         return EXIT_FAILURE;
       }
       ZRestore zr( ZRestore::deriveStorageDirFromBackupsFile( args[ 1 ] ),
                    passwords[ 0 ], config );
-      zr.restoreToStdin( args[ 1 ] );
+      if ( args.size() == 3 )
+        zr.restoreToFile( args[ 1 ], args[ 2 ] );
+      else
+        zr.restoreToStdin( args[ 1 ] );
     }
     else
     if ( strcmp( args[ 0 ], "export" ) == 0 || strcmp( args[ 0 ], "import" ) == 0 )

--- a/zutils.hh
+++ b/zutils.hh
@@ -27,7 +27,10 @@ public:
   ZRestore( string const & storageDir, string const & password,
             Config & configIn );
 
-  /// Restores the data to stdin
+  /// Restores the data to file
+  void restoreToFile( string const & inputFileName, string const & outputFileName );
+
+  /// Restores the data to stdout
   void restoreToStdin( string const & inputFileName );
 };
 


### PR DESCRIPTION
Do two passes instead of just sequentially writing all chunks to the standard output.
On the first pass, all "chunk emit" instructions are remembered together with their output
positions indexed by bundle id, and all "byte emit" instructions are executed using seeks.
On the second pass, all remembered "chunk emit" instructions are executed in the bundle
order. This makes zbackup decompress every used bundle only ONCE instead of doing
it (basically the same work) many times while reading different chunks.

This allows for bigger bundle sizes (I use 32M), which reduces the number of files
in the repository and makes it more cloud-storage-sync friendly, and further improves
the compression ratio.

P.S: This also seems like a way to implement "mounting" of zbackup'ed tarballs :-)