### PR TITLE
Support for backing up from files/directories (vs stdin)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Code contributions:
   Eugene Agafonov <e.a.agafonov@gmail.com>
   Antonia Stevens <a@antevens.com>
   Frank Groeneveld <frank@frankgroeneveld.nl>
+  Tyler Doubrava <tdoubrav@comcast.net>
 
 Feel free to add yourself to this list in your pull-request.
 Please modify this file instead of source headers.

--- a/dir.cc
+++ b/dir.cc
@@ -66,6 +66,14 @@ string getDirName( string const & path )
   return dirname( copy.data() );
 }
 
+string getBaseName( string const & path )
+{
+  char const * c = path.c_str();
+  std::vector< char > copy( c, c + path.size() + 1 );
+
+  return basename( copy.data() );
+}
+
 bool isDirEmpty( string const & path )
 {
   Listing lst(path);

--- a/dir.hh
+++ b/dir.hh
@@ -42,6 +42,9 @@ string getRealPath( string const & );
 /// Returns the directory part of the given path
 string getDirName( string const & );
 
+/// Returns the final path component part of the given path
+string getBaseName( string const & );
+
 /// Checkes whether directory is empty
 bool isDirEmpty( string const & );
 

--- a/ex.hh
+++ b/ex.hh
@@ -32,6 +32,7 @@ virtual ~exName() throw() {} };
 class exName: public exParent { \
   std::string value; \
 public: \
+  exName( ): value( std::string( exDescription ) ) {} \
   exName( std::string const & value_ ): value( std::string( exDescription ) + " " + value_ ) {} \
   exName( char const * value_, unsigned size ): value( std::string( exDescription ) + " " + std::string( value_, size ) ) {} \
 virtual const char * what() const throw() { return value.c_str(); } \

--- a/file.cc
+++ b/file.cc
@@ -37,6 +37,25 @@ bool File::exists( char const * filename ) throw()
 #endif
 }
 
+bool File::special( string const & filename ) throw()
+{
+  bool special = false;
+#ifndef __WIN32
+  struct stat buf;
+
+  if ( stat( filename.c_str(), &buf ) == 0 )
+  {
+    // For our purposes (deciding whether to back up a file),
+    // a file is "special" if it is a socket, or not a regular file.
+    // Softlinks are followed.
+    if ( ( S_IFSOCK == ( S_IFSOCK & buf.st_mode ) ) ||
+         ( S_IFREG != ( S_IFREG & buf.st_mode ) ) )
+      special = true;
+  }
+#endif
+  return special;
+}
+
 void File::erase( std::string const & filename ) throw( exCantErase )
 {
   if ( remove( filename.c_str() ) != 0 )

--- a/file.hh
+++ b/file.hh
@@ -131,6 +131,11 @@ public:
   static bool exists( std::string const & filename ) throw()
   { return exists( filename.c_str() ); }
 
+  /// Returns false when lstat returns stat::st_mode having 
+  /// S_IFREG (filename is a file, or softlink to a file, and
+  /// is not a socket, fifo, device node, etc.
+  static bool special( std::string const & filename ) throw();
+
   ~File() throw();
 
   /// Erases the given file

--- a/zbackup.cc
+++ b/zbackup.cc
@@ -10,6 +10,7 @@ DEF_EX( exSpecifyTwoKeys, "Specify password flag (--non-encrypted or --password-
   " for import/export/passwd operation twice (first for source and second for destination)", std::exception )
 DEF_EX( exNonEncryptedWithKey, "--non-encrypted and --password-file are incompatible", std::exception )
 DEF_EX( exSpecifyEncryptionOptions, "Specify either --password-file or --non-encrypted", std::exception )
+DEF_EX( exSourceInaccessible, "Backup source file/directory is inaccesible", std::exception )
 
 int main( int argc, char *argv[] )
 {
@@ -167,6 +168,8 @@ invalid_option:
 "  Commands:\n"
 "    init <storage path> - initializes new storage\n"
 "    backup <backup file name> - performs a backup from stdin\n"
+"    backup <input_file> <backup file name> - performs a backup from file\n"
+"    backup <input_dir> <backup dir> - performs a backup from directory\n"
 "    restore <backup file name> - restores a backup to stdout\n"
 "    restore <backup file name> <output file name> - restores\n"
 "            a backup to file using two-pass \"cacheless\" process\n"
@@ -219,15 +222,42 @@ invalid_option:
     if ( strcmp( args[ 0 ], "backup" ) == 0 )
     {
       // Perform the backup
-      if ( args.size() != 2 )
+      if ( args.size() < 2 || args.size() > 3)
       {
-        fprintf( stderr, "Usage: %s %s <backup file name>\n",
-                 *argv, args[ 0 ] );
+        fprintf( stderr, "Usage 1: your_backup_command | %s %s <backup file name>\n"
+                         "Usage 2: %s %s <file> <backup file name>\n"
+                         "Usage 3: %s %s <directory> <backup subdirectory>\n",
+                 *argv, args[ 0 ], *argv, args[ 0 ], *argv, args[ 0 ]);
         return EXIT_FAILURE;
       }
-      ZBackup zb( ZBackup::deriveStorageDirFromBackupsFile( args[ 1 ] ),
+      
+      string backupSource, backupsDest;
+      bool dirBackupMode = false;
+      if ( args.size() == 2 )
+        backupsDest = args[ 1 ];
+      else
+      {
+        backupSource = args[ 1 ];
+        if ( Dir::exists( backupSource ) )
+        {
+          dirBackupMode = true;
+          backupsDest = args[ 2 ] + string( "/" ) + Dir::getBaseName( Dir::getRealPath( backupSource ) );
+        }
+        else
+          backupsDest = args[ 2 ];
+      }
+      
+      ZBackup zb( ZBackup::deriveStorageDirFromBackupsFile( backupsDest ),
                   passwords[ 0 ], config );
-      zb.backupFromStdin( args[ 1 ] );
+      if ( args.size() == 2 )
+        zb.backupFromStdin( backupsDest );
+      else 
+      {
+        if ( dirBackupMode )
+          zb.backupFromDirectory( args[ 1 ], backupsDest );
+        else
+          zb.backupFromFile( args[ 1 ], backupsDest );
+      }
     }
     else
     if ( strcmp( args[ 0 ], "restore" ) == 0 )

--- a/zbackup.cc
+++ b/zbackup.cc
@@ -10,7 +10,7 @@ DEF_EX( exSpecifyTwoKeys, "Specify password flag (--non-encrypted or --password-
   " for import/export/passwd operation twice (first for source and second for destination)", std::exception )
 DEF_EX( exNonEncryptedWithKey, "--non-encrypted and --password-file are incompatible", std::exception )
 DEF_EX( exSpecifyEncryptionOptions, "Specify either --password-file or --non-encrypted", std::exception )
-DEF_EX( exSourceInaccessible, "Backup source file/directory is inaccesible", std::exception )
+DEF_EX( exSourceInaccessible, "Backup source file/directory is inaccessible", std::exception )
 
 int main( int argc, char *argv[] )
 {
@@ -241,12 +241,12 @@ invalid_option:
         if ( Dir::exists( backupSource ) )
         {
           dirBackupMode = true;
-          backupsDest = args[ 2 ] + string( "/" ) + Dir::getBaseName( Dir::getRealPath( backupSource ) );
+          backupsDest = Dir::addPath( args[ 2 ], Dir::getBaseName( Dir::getRealPath( backupSource ) ));
         }
         else
           backupsDest = args[ 2 ];
       }
-      
+
       ZBackup zb( ZBackup::deriveStorageDirFromBackupsFile( backupsDest ),
                   passwords[ 0 ], config );
       if ( args.size() == 2 )

--- a/zbackup_base.hh
+++ b/zbackup_base.hh
@@ -34,8 +34,8 @@ class ZBackupBase: public Paths
 public:
   DEF_EX( Ex, "ZBackup exception", std::exception )
   DEF_EX_STR( exWontOverwrite, "Won't overwrite existing file", Ex )
-  DEF_EX( exStdinError, "Error reading from standard input", Ex )
-  DEF_EX( exWontReadFromTerminal, "Won't read data from a terminal", exStdinError )
+  DEF_EX_STR( exInputError, "Error reading from input:", Ex )
+  DEF_EX( exWontReadFromTerminal, "Won't read data from a terminal", Ex )
   DEF_EX( exStdoutError, "Error writing to standard output", Ex )
   DEF_EX( exWontWriteToTerminal, "Won't write data to a terminal", exStdoutError )
   DEF_EX( exSerializeError, "Failed to serialize data", Ex )

--- a/zbackup_base.hh
+++ b/zbackup_base.hh
@@ -35,7 +35,7 @@ public:
   DEF_EX( Ex, "ZBackup exception", std::exception )
   DEF_EX_STR( exWontOverwrite, "Won't overwrite existing file", Ex )
   DEF_EX_STR( exInputError, "Error reading from input:", Ex )
-  DEF_EX( exWontReadFromTerminal, "Won't read data from a terminal", Ex )
+  DEF_EX( exWontReadFromTerminal, "Won't read data from a terminal", exInputError )
   DEF_EX( exStdoutError, "Error writing to standard output", Ex )
   DEF_EX( exWontWriteToTerminal, "Won't write data to a terminal", exStdoutError )
   DEF_EX( exSerializeError, "Failed to serialize data", Ex )

--- a/zutils.cc
+++ b/zutils.cc
@@ -29,11 +29,8 @@ void ZBackup::backupFromStdin( string const & outputFileName )
 /// Backs up the data from a file
 void ZBackup::backupFromFile( string const & inputFileName, string const & outputFileName )
 {
-  FILE* f = fopen( inputFileName.c_str(), "r" );
-  if ( NULL == f )
-    throw exInputError( inputFileName );
-  backupFromFileHandle( inputFileName, f, outputFileName );
-  fclose( f );
+  File inputFile( inputFileName, File::ReadOnly );
+  backupFromFileHandle( inputFileName, inputFile.file(), outputFileName );
 }
 
 /// Backs up the data from a directory
@@ -73,8 +70,13 @@ void ZBackup::backupFromDirectory( string const & inputDirectoryName, string con
           Dir::create( outputPath );
         dirs.push_front( srcPath );
       }
-      else
+      else if ( File::special( srcPath ) )
+        fprintf( stderr, "WARNING: ignoring special file: %s\n", srcPath.c_str() );
+      else 
+      {
+        fprintf( stderr, "backing up %s\n", srcPath.c_str());
         backupFromFile( srcPath, outputPath );
+      }
     }
   }
 }

--- a/zutils.cc
+++ b/zutils.cc
@@ -73,10 +73,7 @@ void ZBackup::backupFromDirectory( string const & inputDirectoryName, string con
       else if ( File::special( srcPath ) )
         fprintf( stderr, "WARNING: ignoring special file: %s\n", srcPath.c_str() );
       else 
-      {
-        fprintf( stderr, "backing up %s\n", srcPath.c_str());
         backupFromFile( srcPath, outputPath );
-      }
     }
   }
 }

--- a/zutils.cc
+++ b/zutils.cc
@@ -23,7 +23,65 @@ void ZBackup::backupFromStdin( string const & outputFileName )
 {
   if ( isatty( fileno( stdin ) ) )
     throw exWontReadFromTerminal();
+  backupFromFileHandle( "stdin", stdin, outputFileName );
+}
 
+/// Backs up the data from a file
+void ZBackup::backupFromFile( string const & inputFileName, string const & outputFileName )
+{
+  FILE* f = fopen( inputFileName.c_str(), "r" );
+  if ( NULL == f )
+    throw exInputError( inputFileName );
+  backupFromFileHandle( inputFileName, f, outputFileName );
+  fclose( f );
+}
+
+/// Backs up the data from a directory
+void ZBackup::backupFromDirectory( string const & inputDirectoryName, string const & outputDirectoryName )
+{
+  std::list< string > dirs;
+  dirs.push_front( inputDirectoryName );
+  
+  while ( !dirs.empty() )
+  {
+    string dir = dirs.front();
+    dirs.pop_front();
+    
+    Dir::Listing list( dir );
+    Dir::Entry e;
+    while ( list.getNext( e ) )
+    {
+      string srcPath = Dir::addPath( dir, e.getFileName() );
+      string relativePath = srcPath.substr( inputDirectoryName.size() );
+
+      // Chop leading slash, which may be present depending on whether the 
+      // command line arg had a trailing slash or not
+      while ( !relativePath.empty() && Dir::separator() == relativePath[ 0 ] )
+        relativePath = relativePath.substr( 1 );
+
+      // Calculate output path as function of path relative to input dir
+      string outputPath = Dir::addPath( outputDirectoryName, relativePath );
+
+      // Make sure directory structure for destination file exists
+      string destDir = Dir::getDirName( outputPath );
+      if ( ! Dir::exists( destDir ) )
+        Dir::create( destDir );
+
+      if ( e.isDir() ) // recurse dir tree
+      {
+        if ( ! Dir::exists( outputPath ) )
+          Dir::create( outputPath );
+        dirs.push_front( srcPath );
+      }
+      else
+        backupFromFile( srcPath, outputPath );
+    }
+  }
+}
+
+/// Backs up the data from a stdio FILE handle
+void ZBackup::backupFromFileHandle( string const & inputName, FILE* inputFileHandle, string const & outputFileName )
+{
   if ( File::exists( outputFileName ) )
     throw exWontOverwrite( outputFileName );
 
@@ -36,20 +94,20 @@ void ZBackup::backupFromStdin( string const & outputFileName )
   for ( ; ; )
   {
     size_t toRead = backupCreator.getInputBufferSize();
-//    dPrintf( "Reading up to %u bytes from stdin\n", toRead );
+//    dPrintf( "Reading up to %u bytes on input\n", toRead );
 
     void * inputBuffer = backupCreator.getInputBuffer();
-    size_t rd = fread( inputBuffer, 1, toRead, stdin );
+    size_t rd = fread( inputBuffer, 1, toRead, inputFileHandle );
 
     if ( !rd )
     {
-      if ( feof( stdin ) )
+      if ( feof( inputFileHandle ) )
       {
-        dPrintf( "No more input on stdin\n" );
+        dPrintf( "No more input from %s\n", inputName.c_str() );
         break;
       }
       else
-        throw exStdinError();
+        throw exInputError( inputName );
     }
 
     sha256.add( inputBuffer, rd );

--- a/zutils.hh
+++ b/zutils.hh
@@ -17,6 +17,15 @@ public:
 
   /// Backs up the data from stdin
   void backupFromStdin( string const & outputFileName );
+
+  /// Backs up the data from a file
+  void backupFromFile( string const & inputFileName, string const & outputFileName );
+
+  /// Backs up the data from a directory
+  void backupFromDirectory( string const & inputDirectoryName, string const & outputDirectoryName );
+
+  /// Backs up the data from a stdio FILE handle
+  void backupFromFileHandle( string const & inputName, FILE* inputFileHandle, string const & outputFileName );
 };
 
 class ZRestore: public ZBackupBase


### PR DESCRIPTION
Quick hack to add support for backing up from files on disk, and directory trees on disk (not just stdin).  Handy when what you're putting into zbackup is a large bunch of small files, instead of, say for instance, tarballs containing them.  Helps to amortize the time spent loading the index files to process addition of a directory tree.