### PR TITLE
Update README and CMakeLists.txt to document cmake >2.8.3 dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2012-2014 Konstantin Isakov <ikm@zbackup.org> and ZBackup contributors, see CONTRIBUTORS
 # Part of ZBackup. Licensed under GNU GPLv2 or later + OpenSSL, see LICENSE
 
-cmake_minimum_required( VERSION 2.8.2 )
+cmake_minimum_required( VERSION 2.8.3 )
 project( zbackup )
 
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The program has the following features:
 
 # Build dependencies
 
- * `cmake` >= 2.8.2 (though it should not be too hard to compile the sources by hand if needed)
+ * `cmake` >= 2.8.3 (though it should not be too hard to compile the sources by hand if needed)
  * `libssl-dev` for all encryption, hashing and random numbers
  * `libprotobuf-dev` and `protobuf-compiler` for data serialization
  * `liblzma-dev` for compression


### PR DESCRIPTION
Changes to cmake config quite a while back break debian squeeze compatibility, which uses cmake 2.8.2.  That itself is ok, but the error message is a bit confusing.  Document apparent dependency on cmake >2.8.3.  See also https://github.com/LuaDist/Repository/issues/135