### PR TITLE
Introduce backupcreator a alternative to tar

### DIFF
--- a/tools/backupcreator/CMakeLists.txt
+++ b/tools/backupcreator/CMakeLists.txt
@@ -4,7 +4,9 @@
 cmake_minimum_required( VERSION 2.6.0 )
 project( backupcreator )
 
-set( CMAKE_BUILD_TYPE Release )
+if( NOT CMAKE_BUILD_TYPE )
+  set( CMAKE_BUILD_TYPE Release )
+endif( NOT CMAKE_BUILD_TYPE )
 
 find_package( Protobuf REQUIRED )
 include_directories( ${PROTOBUF_INCLUDE_DIRS} )

--- a/tools/backupcreator/CMakeLists.txt
+++ b/tools/backupcreator/CMakeLists.txt
@@ -12,6 +12,10 @@ find_package( Protobuf REQUIRED )
 include_directories( ${PROTOBUF_INCLUDE_DIRS} )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
+find_package( ZLIB REQUIRED )
+include_directories( ${ZLIB_INCLUDE_DIRS} )
+
+
 find_program( PROTOBUF_PROTOC_CHECK NAMES protoc DOC "Protobuf compiler binary" )
 
 IF( ${PROTOBUF_PROTOC_CHECK} STREQUAL "PROTOBUF_PROTOC_CHECK-NOTFOUND" )
@@ -25,6 +29,7 @@ add_executable( backupcreator ${sourceFiles} ${protoSrcs} ${protoHdrs} )
 
 target_link_libraries( backupcreator
   ${PROTOBUF_LIBRARIES}
+  ${ZLIB_LIBRARIES}
 )
 
 install( TARGETS backupcreator DESTINATION bin )

--- a/tools/backupcreator/CMakeLists.txt
+++ b/tools/backupcreator/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) 2015 Markus Knetschke <markus.knetschke@gmail.com>
+# Part of ZBackup. Licensed under GNU GPLv2 or later + OpenSSL, see LICENSE
+
+cmake_minimum_required( VERSION 2.6.0 )
+project( backupcreator )
+
+set( CMAKE_BUILD_TYPE Release )
+
+find_package( Protobuf REQUIRED )
+include_directories( ${PROTOBUF_INCLUDE_DIRS} )
+include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
+
+find_program( PROTOBUF_PROTOC_CHECK NAMES protoc DOC "Protobuf compiler binary" )
+
+IF( ${PROTOBUF_PROTOC_CHECK} STREQUAL "PROTOBUF_PROTOC_CHECK-NOTFOUND" )
+  MESSAGE( FATAL_ERROR "Could not find protobuf compiler. Make sure protobuf-compiler package is installed." )
+ENDIF( ${PROTOBUF_PROTOC_CHECK} STREQUAL "PROTOBUF_PROTOC_CHECK-NOTFOUND" )
+
+PROTOBUF_GENERATE_CPP( protoSrcs protoHdrs backupcreator.proto )
+
+file( GLOB sourceFiles "*.cc" )
+add_executable( backupcreator ${sourceFiles} ${protoSrcs} ${protoHdrs} )
+
+target_link_libraries( backupcreator
+  ${PROTOBUF_LIBRARIES}
+)
+
+install( TARGETS backupcreator DESTINATION bin )

--- a/tools/backupcreator/backupcreator.cc
+++ b/tools/backupcreator/backupcreator.cc
@@ -201,8 +201,11 @@ int backup(uint32_t alignment)
   readFileTree(&backup, alignment);
   
   outputData(&backup, &std::cout, alignment);
-  
+  return 0;
 }
+
+
+
 void printHelp()
 {
   std::cout << "Use: backupcreator [backup | restore] [align size in bytes]" << std::endl;
@@ -226,6 +229,7 @@ int main(int argc, const char* argv[])
     {
       align = atol(argv[2]);
     }
+    return backup(align);
   }
   else if(argv[1] == "restore")
   {

--- a/tools/backupcreator/backupcreator.cc
+++ b/tools/backupcreator/backupcreator.cc
@@ -1,0 +1,200 @@
+#include <iostream>
+#include <fstream>
+#include <ostream>
+
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include "backupcreator.pb.h"
+
+
+#define ALIGN (16*1024)
+#define ALIGN_SIZE(A) ((A % ALIGN == 0) ? (A / ALIGN) : (A / ALIGN + 1))
+
+char *readlink_malloc (const char *filename)
+{
+  int size = 100;
+  char *buffer = NULL;
+
+  while(1)
+  {
+    buffer = (char *)realloc(buffer, size);
+    if(buffer == NULL)
+      return NULL;
+    
+    int nchars = readlink(filename, buffer, size);
+    if(nchars < 0)
+    {
+      free(buffer);
+      return NULL;
+    }
+    if(nchars < size)
+      return buffer;
+    size *= 2;
+    }
+}
+
+void readBackupItems(Backup *backup)
+{
+  uint64_t currentPos = 0;
+  while(true)
+  {
+    std::string path;
+    
+    std::getline(std::cin, path, '\0');
+    
+    if(std::cin.eof())
+      break;
+    
+    if(std::cin.fail())
+      break;
+    
+    struct stat64 statresult;
+    
+    if(lstat64(path.c_str(), &statresult))
+    {
+      std::cerr << "Error: unable to stat file " << path;
+      continue;
+    }
+        
+    Backup_Item *item = backup->add_item();
+    item->set_path(path);
+    item->set_owner(statresult.st_uid);
+    item->set_group(statresult.st_gid);
+    item->set_atime((uint64_t)statresult.st_atim.tv_sec);
+    item->set_atimenano((uint64_t)statresult.st_atim.tv_nsec);
+    item->set_ctime((uint64_t)statresult.st_ctim.tv_sec);
+    item->set_ctimenano((uint64_t)statresult.st_ctim.tv_nsec);
+    item->set_mtime((uint64_t)statresult.st_mtim.tv_sec);
+    item->set_mtimenano((uint64_t)statresult.st_mtim.tv_nsec);
+    item->set_accessrights(statresult.st_mode & ~__S_IFMT);
+    
+    switch(statresult.st_mode & __S_IFMT) {
+      case __S_IFDIR:
+        item->mutable_directory();
+        break;
+      case __S_IFCHR:
+      {
+        Backup_Item_Device *dev = item->mutable_device();
+        dev->set_deviceid(statresult.st_rdev);
+        dev->set_block(false);
+      }
+        break;
+      case __S_IFBLK:
+      {
+        Backup_Item_Device *dev = item->mutable_device();
+        dev->set_deviceid(statresult.st_rdev);
+        dev->set_block(true);
+      }
+        break;
+      case __S_IFREG:
+      {
+        Backup_Item_File *file = item->mutable_file();
+        file->set_position(currentPos);
+        file->set_size(statresult.st_size);
+        currentPos += ALIGN_SIZE(statresult.st_size);
+      }
+        break;
+      case __S_IFIFO:
+        item->mutable_fifo();
+        break;
+      case __S_IFLNK:
+      {
+        Backup_Item_Symlink *symlink = item->mutable_symlink();
+        char *link = readlink_malloc(path.c_str());
+        
+        if(link == NULL)
+        {
+          std::cerr << "Unable to read link" << path << std::endl;
+          return;
+        }
+        symlink->set_target(link);
+        
+        free(link);
+      }
+        break;
+      case __S_IFSOCK:
+        item->mutable_socket();
+        break;
+    }
+    
+  }
+  
+}
+
+uint64_t outputFileData(const std::string *path, std::ostream *stream)
+{
+  std::fstream file(path->c_str(), std::fstream::in | std::fstream::binary);
+  
+  uint64_t total = 0;
+  
+  char buffer[4096];
+  while(true) {
+    file.read(buffer, 4096);
+  
+    uint64_t readed = file.gcount();
+    if(readed == 0)
+      break;
+      
+    stream->write(buffer, readed);
+    total += readed;
+  }
+  file.close();
+  return total;
+}
+
+void outputAlign(uint64_t written, std::ostream *stream)
+{
+  uint64_t alignToWrite = ALIGN - (written % ALIGN);
+  if(ALIGN == alignToWrite)
+    return;
+  
+  char *alignmentBuffer = (char *)malloc(alignToWrite);
+  memset(alignmentBuffer, '\0', alignToWrite);
+  if(alignmentBuffer == NULL)
+  {
+    std::cerr << "Unable to allocate alignmentBuffer" << std::endl;
+    return;
+  }
+  
+  stream->write(alignmentBuffer, alignToWrite);
+}
+
+void outputData(Backup *backup, std::ostream *stream)
+{
+  std::string backupString = backup->SerializeAsString();
+  
+  *stream << backupString;
+  
+  outputAlign(backupString.length(), stream);
+  
+  uint64_t posAlign = ALIGN_SIZE(backupString.length());
+  
+  for(uint64_t i = 0; i < backup->item_size(); i++)
+  {
+    Backup_Item item = backup->item(i);
+    if(!item.has_file())
+      continue;
+    
+    uint64_t written = outputFileData(&item.path(), stream);
+    
+    if(written != item.file().size())
+    {
+      std::cerr << "File " << item.path() << " has changed size. Written " << written << " should be "<< item.file().size() << std::endl;
+    }
+    
+    posAlign += ALIGN_SIZE(written);
+    outputAlign(written, stream);
+  }
+}
+
+int main()
+{
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  
+  Backup backup;
+  readBackupItems(&backup);
+  
+  outputData(&backup, &std::cout);
+}

--- a/tools/backupcreator/backupcreator.cc
+++ b/tools/backupcreator/backupcreator.cc
@@ -383,7 +383,7 @@ void writeFileData(Backup_Item *item, std::istream *stream, uint32_t alignsize, 
   skipBytes(stream, alignToSkip);
 }
 
-void createFiles(Backup *backup, std::istream *stream)
+void createFiles(Backup *backup, std::istream *stream, ChecksumBlock *cb)
 {
   uint64_t startoffset = stream->tellg();
   
@@ -396,7 +396,6 @@ void createFiles(Backup *backup, std::istream *stream)
     std::string path = item.path();
     struct stat64 statresult;
     
-    ChecksumBlock cb;
     
     if(!lstat64(path.c_str(), &statresult))
     {
@@ -409,7 +408,7 @@ void createFiles(Backup *backup, std::istream *stream)
         uint32_t checksum = 0;
         writeFileData(&item, stream, backup->alignsize(), startoffset, checksum);
         
-        ChecksumBlock_Checksum *c = cb.add_checksum();
+        ChecksumBlock_Checksum *c = cb->add_checksum();
         c->set_id(i);
         c->set_sum(checksum);
       }
@@ -434,7 +433,10 @@ int restore()
   // stage 1 create path tree
   createFileTree(backup);
   
-  createFiles(backup, &std::cin);
+  ChecksumBlock cb;
+  
+  createFiles(backup, &std::cin, cb);
+  
   
 }
 

--- a/tools/backupcreator/backupcreator.cc
+++ b/tools/backupcreator/backupcreator.cc
@@ -435,7 +435,7 @@ int restore()
   
   ChecksumBlock cb;
   
-  createFiles(backup, &std::cin, cb);
+  createFiles(backup, &std::cin, &cb);
   
   
 }

--- a/tools/backupcreator/backupcreator.cc
+++ b/tools/backupcreator/backupcreator.cc
@@ -58,9 +58,9 @@ void readBackupItems(Backup *backup)
       continue;
     }
     // skip  fifos and sockets we can't restore them anyway
-    if(statresult.st_mode & __S_IFIFO || statresult.st_mode & __S_IFSOCK)
+    if((statresult.st_mode & __S_IFMT == __S_IFSOCK) || (statresult.st_mode & __S_IFMT == __S_IFIFO))
     {
-      std::cerr << "Skipped fifo or socket " << path << std::endl;
+      std::cerr << "Skipped fifo or socket " << path << " " << statresult.st_mode << std::endl;
       continue;
     }
         
@@ -166,12 +166,13 @@ void outputAlign(uint64_t written, std::ostream *stream)
 void outputData(Backup *backup, std::ostream *stream)
 {
   std::string backupString = backup->SerializeAsString();
-  
+ 
+  *stream << (uint64_t)backupString.length();
   *stream << backupString;
   
-  outputAlign(backupString.length(), stream);
+  outputAlign(backupString.length() * 8, stream);
   
-  uint64_t posAlign = ALIGN_SIZE(backupString.length());
+  uint64_t posAlign = ALIGN_SIZE(backupString.length() * 8);
   
   for(uint64_t i = 0; i < backup->item_size(); i++)
   {
@@ -190,6 +191,8 @@ void outputData(Backup *backup, std::ostream *stream)
     outputAlign(written, stream);
   }
 }
+
+
 
 int main()
 {

--- a/tools/backupcreator/backupcreator.cc
+++ b/tools/backupcreator/backupcreator.cc
@@ -57,6 +57,12 @@ void readBackupItems(Backup *backup)
       std::cerr << "Error: unable to stat file " << path;
       continue;
     }
+    // skip  fifos and sockets we can't restore them anyway
+    if(statresult.st_mode & __S_IFIFO || statresult.st_mode & __S_IFSOCK)
+    {
+      std::cerr << "Skipped fifo or socket " << path << std::endl;
+      continue;
+    }
         
     Backup_Item *item = backup->add_item();
     item->set_path(path);
@@ -96,9 +102,6 @@ void readBackupItems(Backup *backup)
         currentPos += ALIGN_SIZE(statresult.st_size);
       }
         break;
-      case __S_IFIFO:
-        item->mutable_fifo();
-        break;
       case __S_IFLNK:
       {
         Backup_Item_Symlink *symlink = item->mutable_symlink();
@@ -113,9 +116,6 @@ void readBackupItems(Backup *backup)
         
         free(link);
       }
-        break;
-      case __S_IFSOCK:
-        item->mutable_socket();
         break;
     }
     

--- a/tools/backupcreator/backupcreator.cc
+++ b/tools/backupcreator/backupcreator.cc
@@ -159,6 +159,8 @@ void outputAlign(uint64_t written, std::ostream *stream)
   }
   
   stream->write(alignmentBuffer, alignToWrite);
+  
+  free(alignmentBuffer);
 }
 
 void outputData(Backup *backup, std::ostream *stream)
@@ -197,4 +199,6 @@ int main()
   readBackupItems(&backup);
   
   outputData(&backup, &std::cout);
+  
+  google::protobuf::ShutdownProtobufLibrary();
 }

--- a/tools/backupcreator/backupcreator.cc
+++ b/tools/backupcreator/backupcreator.cc
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <ostream>
 #include <string>
+#include <cstring>
 
 #include <sys/stat.h>
 #include <unistd.h>
@@ -204,7 +205,33 @@ int backup(uint32_t alignment)
   return 0;
 }
 
+Backup *readHeader(std::istream *stream)
+{
+  uint64_t size = 0;
+  
+  stream->read(reinterpret_cast<char *>(&size), sizeof(size));
+  
+  void *buffer = malloc(size);
+  if(buffer == NULL)
+    return NULL;
+  
+  stream->read(reinterpret_cast<char *>(buffer), size);
+  
+  Backup *backup = new Backup();
+  backup->ParseFromArray(buffer, size);
+  
+  uint32_t alignmentToSkip = backup->alignsize() - ALIGN_SIZE(size, backup->alignsize());
+  
+  
+  return backup;
+}
 
+int restore()
+{
+  Backup *backup = readHeader(&std::cin);
+  
+  std::cout << "Size: " << backup->item_size() << std::endl;
+}
 
 void printHelp()
 {
@@ -223,7 +250,7 @@ int main(int argc, const char* argv[])
     return 1;
   }
   
-  if(argv[1] == "backup")
+  if(strncmp("backup", argv[1], sizeof("backup")) == 0)
   {
     if(argc == 3)
     {
@@ -231,8 +258,9 @@ int main(int argc, const char* argv[])
     }
     return backup(align);
   }
-  else if(argv[1] == "restore")
+  else if(strncmp("restore", argv[1], sizeof("restore")) == 0)
   {
+    return restore();
   }
   else
   {

--- a/tools/backupcreator/backupcreator.cc
+++ b/tools/backupcreator/backupcreator.cc
@@ -231,6 +231,10 @@ void outputData(Backup *backup, std::ostream *stream, uint32_t alignment)
   void *checksumBuffer = malloc(checksumSize);
   backup->SerializeToArray(checksumBuffer, checksumSize);
   
+  // write checksum Block size
+  stream->write(reinterpret_cast<const char *>(&checksumSize), sizeof(checksumSize));
+  
+  // write checksum Block
   stream->write(reinterpret_cast<const char *>(checksumBuffer), checksumSize);
   
   free(checksumBuffer);

--- a/tools/backupcreator/backupcreator.proto
+++ b/tools/backupcreator/backupcreator.proto
@@ -41,17 +41,4 @@ message Backup
     }
   }
   repeated Item item = 2;
-  
-  required uint64 checksumBlockPos = 3;
-}
-
-message ChecksumBlock
-{
-  message Checksum
-  {
-    required uint64 id = 1;
-    required fixed32 sum = 2;
-  }
-
-  repeated Checksum checksum = 1;
 }

--- a/tools/backupcreator/backupcreator.proto
+++ b/tools/backupcreator/backupcreator.proto
@@ -1,5 +1,7 @@
 message Backup
 {
+  required uint32 alignSize = 1;
+
   message Item
   {
     required bytes path = 1;
@@ -40,5 +42,5 @@ message Backup
       Symlink symlink = 15;
     }
   }
-  repeated Item item = 1;
+  repeated Item item = 2;
 }

--- a/tools/backupcreator/backupcreator.proto
+++ b/tools/backupcreator/backupcreator.proto
@@ -28,24 +28,16 @@ message Backup
       required bool block = 1;
       required uint32 deviceID = 2;
     }
-    message Fifo
-    {
-    }
     message Symlink
     {
       required bytes target = 1;
-    }
-    message Socket
-    {
     }
     oneof type
     {
       File file = 12;
       Directory directory = 13;
       Device device = 14;
-      Fifo fifo = 15;
-      Symlink symlink = 16;
-      Socket socket = 17;
+      Symlink symlink = 15;
     }
   }
   repeated Item item = 1;

--- a/tools/backupcreator/backupcreator.proto
+++ b/tools/backupcreator/backupcreator.proto
@@ -41,6 +41,8 @@ message Backup
     }
   }
   repeated Item item = 2;
+  
+  required uint64 checksumBlockPos = 3;
 }
 
 message ChecksumBlock

--- a/tools/backupcreator/backupcreator.proto
+++ b/tools/backupcreator/backupcreator.proto
@@ -1,0 +1,52 @@
+message Backup
+{
+  message Item
+  {
+    required bytes path = 1;
+    
+    required uint32 accessRights = 3;
+    required uint32 owner = 4;
+    required uint32 group = 5;
+    
+    required uint64 atime = 6;
+    required uint64 atimeNano = 7;
+    required uint64 mtime = 8;
+    required uint64 mtimeNano = 9;
+    required uint64 ctime = 10;
+    required uint64 ctimeNano = 11;
+    
+    message File
+    {
+      required uint64 size = 1;
+      required uint64 position = 2;
+    }
+    message Directory
+    {
+    }
+    message Device
+    {
+      required bool block = 1;
+      required uint32 deviceID = 2;
+    }
+    message Fifo
+    {
+    }
+    message Symlink
+    {
+      required bytes target = 1;
+    }
+    message Socket
+    {
+    }
+    oneof type
+    {
+      File file = 12;
+      Directory directory = 13;
+      Device device = 14;
+      Fifo fifo = 15;
+      Symlink symlink = 16;
+      Socket socket = 17;
+    }
+  }
+  repeated Item item = 1;
+}

--- a/tools/backupcreator/backupcreator.proto
+++ b/tools/backupcreator/backupcreator.proto
@@ -14,8 +14,6 @@ message Backup
     required uint64 atimeNano = 7;
     required uint64 mtime = 8;
     required uint64 mtimeNano = 9;
-    required uint64 ctime = 10;
-    required uint64 ctimeNano = 11;
     
     message File
     {
@@ -36,11 +34,22 @@ message Backup
     }
     oneof type
     {
-      File file = 12;
-      Directory directory = 13;
-      Device device = 14;
-      Symlink symlink = 15;
+      File file = 10;
+      Directory directory = 11;
+      Device device = 12;
+      Symlink symlink = 13;
     }
   }
   repeated Item item = 2;
+}
+
+message ChecksumBlock
+{
+  message Checksum
+  {
+    required uint64 id = 1;
+    required fixed32 sum = 2;
+  }
+
+  repeated Checksum checksum = 1;
 }


### PR DESCRIPTION
As written in #42 tar handles everything in line and without aligning which dosn't work well with deduplication and a lot of blocks get re-added after a directory rename.
Backupcreator faces this with having a index at front and the file data apart in single aligned parts in the stream.
My testdata (4 System snapshots from one system in different states 52GB) produces a 13.775GB zbackup dir instate a 15.365GB dir with tar.
Additionally backupcreator saves crc sums just in case...
Its in a quite raw state, a lot of errors didn't get handles correctly and some thinks aren't clear yet (inline checksums as example) but it already backups my systems without errors on a daily base. I think its now ready for receive tests and work from others too.

Usage:
Backup: `find [your find expression] -print0 | backupcreator backup [align size] | zbackup [params]`
Restore: `zbackup [params] | backupcreator restore`

backupcreator restores every path the same way as it got saved
`find [path]` prefixes every found file with the provided path. If the path is absolute it prints absolute paths and backupcreator stores them absolute. On restoring this it tries to restore the files in the same absolute path!
Currently there is no parameter for restoring absolute paths relative to a directory or ignoring path elements so the safest way is cd into the root backup dir and use find without a path argument.
Additionally there is no "target path" argument, relative stored path get restored relative to the current working directory.

The alignment size is a tradeoff between better deduplication and time, some tests:

| Alignment | End Size | Whole duration |
| --- | --- | --- |
| 1 (no) | 13.794GB | 2:50:52 |
| 4096 | 13.788GB | 2:59:01 |
| 16384 | 13.778GB | 3:42:58 |
| 65536 | 13.775GB | 6:44:48 |
| tar | 15.365GB | 3:47:15 |
