### PR TITLE
implement POC NBD server in zbackup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if ( ZBACKUP_VERSION )
   MESSAGE("ZBackup version ${ZBACKUP_VERSION}")
 endif( ZBACKUP_VERSION )
 
-file( GLOB sourceFiles "*.cc" )
+file( GLOB sourceFiles "*.cc" "*.c" )
 add_executable( zbackup ${sourceFiles} ${protoSrcs} ${protoHdrs} )
 
 target_link_libraries( zbackup

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,6 +17,7 @@ Code contributions:
   Antonia Stevens <a@antevens.com>
   Frank Groeneveld <frank@frankgroeneveld.nl>
   Tyler Doubrava <tdoubrav@comcast.net>
+  Vladimir Rutsky <vladimir@rutsky.org>
 
 Feel free to add yourself to this list in your pull-request.
 Please modify this file instead of source headers.

--- a/buse.c
+++ b/buse.c
@@ -1,0 +1,232 @@
+/*
+ * buse - block-device userspace extensions
+ * Copyright (C) 2013 Adam Cozzette
+ *
+ * This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/types.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "buse.h"
+
+/*
+ * These helper functions were taken from cliserv.h in the nbd distribution.
+ */
+#ifdef WORDS_BIGENDIAN
+u_int64_t ntohll(u_int64_t a) {
+  return a;
+}
+#else
+u_int64_t ntohll(u_int64_t a) {
+  u_int32_t lo = a & 0xffffffff;
+  u_int32_t hi = a >> 32U;
+  lo = ntohl(lo);
+  hi = ntohl(hi);
+  return ((u_int64_t) lo) << 32U | hi;
+}
+#endif
+#define htonll ntohll
+
+// Debug message
+#ifdef NDEBUG
+#define debug_print( ... )
+#else
+#define debug_print(fmt, ...) \
+    do { fprintf(stderr, "[DEBUG] %s:%d:%s(): " fmt, __FILE__, \
+        __LINE__, __func__, __VA_ARGS__); } while (0)
+#endif
+
+static int read_all(int fd, char* buf, size_t count)
+{
+  int bytes_read;
+
+  while (count > 0) {
+    bytes_read = read(fd, buf, count);
+    assert(bytes_read > 0);
+    buf += bytes_read;
+    count -= bytes_read;
+  }
+  assert(count == 0);
+
+  return 0;
+}
+
+static int write_all(int fd, char* buf, size_t count)
+{
+  int bytes_written;
+
+  while (count > 0) {
+    bytes_written = write(fd, buf, count);
+    assert(bytes_written > 0);
+    buf += bytes_written;
+    count -= bytes_written;
+  }
+  assert(count == 0);
+
+  return 0;
+}
+
+int buse_main(const char* dev_file, const struct buse_operations *aop, void *userdata)
+{
+  int sp[2];
+  int nbd, sk, err, tmp_fd;
+  u_int64_t from;
+  u_int32_t len;
+  ssize_t bytes_read;
+  struct nbd_request request;
+  struct nbd_reply reply;
+  void *chunk;
+
+  err = socketpair(AF_UNIX, SOCK_STREAM, 0, sp);
+  assert(!err);
+
+  nbd = open(dev_file, O_RDWR);
+  if (nbd == -1) {
+    fprintf(stderr, 
+        "Failed to open `%s': %s\n"
+        "Is kernel module `nbd' is loaded and you have permissions "
+        "to access the device?\n", dev_file, strerror(errno));
+    return 1;
+  }
+
+  err = ioctl(nbd, NBD_SET_SIZE, aop->size);
+  assert(err != -1);
+  err = ioctl(nbd, NBD_CLEAR_SOCK);
+  assert(err != -1);
+
+  if (!fork()) {
+    /* The child needs to continue setting things up. */
+    close(sp[0]);
+    sk = sp[1];
+
+    if(ioctl(nbd, NBD_SET_SOCK, sk) == -1){
+      fprintf(stderr, "ioctl(nbd, NBD_SET_SOCK, sk) failed.[%s]\n", strerror(errno));
+    }
+#if defined NBD_SET_FLAGS && defined NBD_FLAG_SEND_TRIM
+    else if(ioctl(nbd, NBD_SET_FLAGS, NBD_FLAG_SEND_TRIM) == -1){
+      fprintf(stderr, "ioctl(nbd, NBD_SET_FLAGS, NBD_FLAG_SEND_TRIM) failed.[%s]\n", strerror(errno));
+    }
+#endif
+    else{
+      err = ioctl(nbd, NBD_DO_IT);
+      fprintf(stderr, "nbd device terminated with code %d\n", err);
+      if (err == -1)
+	fprintf(stderr, "%s\n", strerror(errno));
+    }
+
+    ioctl(nbd, NBD_CLEAR_QUE);
+    ioctl(nbd, NBD_CLEAR_SOCK);
+
+    exit(0);
+  }
+
+  /* The parent opens the device file at least once, to make sure the
+   * partition table is updated. Then it closes it and starts serving up
+   * requests. */
+
+  tmp_fd = open(dev_file, O_RDONLY);
+  assert(tmp_fd != -1);
+  close(tmp_fd);
+
+  close(sp[1]);
+  sk = sp[0];
+
+  reply.magic = htonl(NBD_REPLY_MAGIC);
+  reply.error = htonl(0);
+
+  while ((bytes_read = read(sk, &request, sizeof(request))) > 0) {
+    assert(bytes_read == sizeof(request));
+    memcpy(reply.handle, request.handle, sizeof(reply.handle));
+    reply.error = htonl(0);
+
+    len = ntohl(request.len);
+    from = ntohll(request.from);
+    assert(request.magic == htonl(NBD_REQUEST_MAGIC));
+
+    switch(ntohl(request.type)) {
+      /* I may at some point need to deal with the the fact that the
+       * official nbd server has a maximum buffer size, and divides up
+       * oversized requests into multiple pieces. This applies to reads
+       * and writes.
+       */
+    case NBD_CMD_READ:
+      debug_print("Request for read of size %d\n", len);
+      /* Fill with zero in case actual read is not implemented */
+      chunk = malloc(len);
+      if (aop->read) {
+        reply.error = aop->read(chunk, len, from, userdata);
+      } else {
+        /* If user not specified read operation, return EPERM error */
+        reply.error = htonl(EPERM);
+      }
+      write_all(sk, (char*)&reply, sizeof(struct nbd_reply));
+      write_all(sk, (char*)chunk, len);
+
+      free(chunk);
+      break;
+    case NBD_CMD_WRITE:
+      debug_print("Request for write of size %d\n", len);
+      chunk = malloc(len);
+      read_all(sk, chunk, len);
+      if (aop->write) {
+        reply.error = aop->write(chunk, len, from, userdata);
+      } else {
+        /* If user not specified write operation, return EPERM error */
+        reply.error = htonl(EPERM);
+      }
+      free(chunk);
+      write_all(sk, (char*)&reply, sizeof(struct nbd_reply));
+      break;
+    case NBD_CMD_DISC:
+      /* Handle a disconnect request. */
+      if (aop->disc) {
+        aop->disc(userdata);
+      }
+      return 0;
+#ifdef NBD_FLAG_SEND_FLUSH
+    case NBD_CMD_FLUSH:
+      if (aop->flush) {
+        reply.error = aop->flush(userdata);
+      }
+      write_all(sk, (char*)&reply, sizeof(struct nbd_reply));
+      break;
+#endif
+#ifdef NBD_FLAG_SEND_TRIM
+    case NBD_CMD_TRIM:
+      if (aop->trim) {
+        reply.error = aop->trim(from, len, userdata);
+      }
+      write_all(sk, (char*)&reply, sizeof(struct nbd_reply));
+      break;
+#endif
+    default:
+      assert(0);
+    }
+  }
+  if (bytes_read == -1)
+    fprintf(stderr, "%s\n", strerror(errno));
+  return 0;
+}

--- a/buse.h
+++ b/buse.h
@@ -1,0 +1,29 @@
+#ifndef BUSE_H_INCLUDED
+#define BUSE_H_INCLUDED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
+  /* Most of this file was copied from nbd.h in the nbd distribution. */
+#include <linux/types.h>
+#include <sys/types.h>
+#include <linux/nbd.h>
+
+  struct buse_operations {
+    int (*read)(void *buf, u_int32_t len, u_int64_t offset, void *userdata);
+    int (*write)(const void *buf, u_int32_t len, u_int64_t offset, void *userdata);
+    void (*disc)(void *userdata);
+    int (*flush)(void *userdata);
+    int (*trim)(u_int64_t from, u_int32_t len, void *userdata);
+
+    u_int64_t size;
+  };
+
+  int buse_main(const char* dev_file, const struct buse_operations *bop, void *userdata);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BUSE_H_INCLUDED */

--- a/zbackup.cc
+++ b/zbackup.cc
@@ -173,6 +173,8 @@ invalid_option:
 "    restore <backup file name> - restores a backup to stdout\n"
 "    restore <backup file name> <output file name> - restores\n"
 "            a backup to file using two-pass \"cacheless\" process\n"
+"    nbd <backup file name> /dev/nbd0\n"
+"            start NBD server that will serve backup data as block device\n"
 "    export <source storage path> <destination storage path> -\n"
 "            performs export from source to destination storage\n"
 "    import <source storage path> <destination storage path> -\n"
@@ -276,6 +278,20 @@ invalid_option:
         zr.restoreToFile( args[ 1 ], args[ 2 ] );
       else
         zr.restoreToStdin( args[ 1 ] );
+    }
+    else
+    if ( strcmp( args[ 0 ], "nbd" ) == 0 )
+    {
+      // Start NBD server
+      if ( args.size() != 3 )
+      {
+        fprintf( stderr, "Usage: %s %s <backup file name> /dev/nbd0\n",
+                 *argv , args[ 0 ] );
+        return EXIT_FAILURE;
+      }
+      ZRestore zr( ZRestore::deriveStorageDirFromBackupsFile( args[ 1 ] ),
+                   passwords[ 0 ], config );
+      zr.startNBDServer( args[ 1 ], args[ 2 ] );
     }
     else
     if ( strcmp( args[ 0 ], "export" ) == 0 || strcmp( args[ 0 ], "import" ) == 0 )

--- a/zutils.hh
+++ b/zutils.hh
@@ -45,6 +45,9 @@ public:
 
   /// Restores the data to stdout
   void restoreToStdin( string const & inputFileName );
+
+  /// Starts NBD server that serves backup data as block device with random access
+  void startNBDServer( string const & inputFileName, string const & nbdDevice );
 };
 
 class ZExchange


### PR DESCRIPTION
Allows to serve backup contents as block device.
Useful if backup is an disk partition image.

If `/repo/backups/sda1-2016-02-01` is `/dev/sda1` partition backup, then you can do:

```
# Load Linux NBD driver
sudo modprobe nbd
# Start serving backup as /dev/nbd0
sudo zbackup --non-encrypted nbd /repo/backups/sda1-2016-02-01 /dev/nbd0 &
# Mount NBD as real read-only filesystem
sudo mount -o ro /dev/nbd0 /mnt
```

Tested on Ubuntu 14.04 64-bit with backup of 80 GB NTFS partition.

This is a quickly done Proof of Concept implementation.
It's not heavily tested and not profiled (however I haven't noticed any significant filesystem lags).

Later NBD code can be extracted to BUSE and BUSE can be dropped completely.
See https://github.com/zbackup/zbackup/commit/df02e1b00098b17a1ebd60b83c16b1b8eca681c9 commit message for details about BUSE. 