### PR TITLE
For the reasons of interoperability, dual-license the zbackup.proto f…

### DIFF
--- a/zbackup.proto
+++ b/zbackup.proto
@@ -1,5 +1,30 @@
-// Copyright (c) 2012-2014 Konstantin Isakov <ikm@zbackup.org> and ZBackup contributors, see CONTRIBUTORS
+// Copyright (c) 2012-2016 Konstantin Isakov <ikm@zbackup.org> and ZBackup contributors, see CONTRIBUTORS
 // Part of ZBackup. Licensed under GNU GPLv2 or later + OpenSSL, see LICENSE
+
+
+// For the reasons of interoperability, this file, and this file only, is also
+// licensed under a permissive MIT license:
+
+// Copyright (c) 2012-2016 Konstantin Isakov <ikm@zbackup.org> and ZBackup
+// contributors, see https://github.com/zbackup/zbackup/blob/master/CONTRIBUTORS
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this file, and this file only, to deal in this file without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the file, and to permit persons
+// to whom the file is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 
 // Protobuffers used in zbackup
 


### PR DESCRIPTION
…ile under both GPLv2+ and MIT. This does not apply to the rest of the source code.