### PR TITLE
reindex mode to recreate an index from bundles

### DIFF
--- a/bundle.cc
+++ b/bundle.cc
@@ -264,4 +264,22 @@ string generateFileName( Id const & id, string const & bundlesDir,
 
   return string( Dir::addPath( level1, hex ) );
 }
+
+Id idFromFileName( string const & fileName )
+{
+  string baseName = Dir::getBaseName( fileName );
+
+  string bin = Utils::fromHex(baseName);
+
+  if ( bin.length() != IdSize )
+  {
+    throw exIllegalFileName();
+  }
+
+  Id id;
+  memcpy( id.blob, bin.data(), IdSize );
+
+  return id;
+}
+
 }

--- a/bundle.hh
+++ b/bundle.hh
@@ -48,6 +48,9 @@ struct Id
 
 STATIC_ASSERT( sizeof( Id ) == IdSize );
 
+DEF_EX( Ex, "Bundle exception", std::exception )
+DEF_EX( exIllegalFileName, "Illegal bundle file name", Ex )
+
 /// Reads the bundle and allows accessing chunks
 class Reader: NoCopy
 {
@@ -118,6 +121,7 @@ public:
 /// already
 string generateFileName( Id const &, string const & bundlesDir,
                          bool createDirs );
+Id idFromFileName( string const & fileName );
 }
 
 #endif

--- a/utils.cc
+++ b/utils.cc
@@ -134,4 +134,55 @@ string toHex( unsigned char const * in, unsigned size )
   return result;
 }
 
+// Converts hex input string to binary. Accepts upper or lower case.
+// For input with illegal or odd number of characters, returns empty string.
+string fromHex( string const & in )
+{
+  string result;
+
+  if ( in.length() % 2 != 0 )
+  {
+    return result;
+  }
+
+  result.reserve( in.length() / 2 );
+
+  for ( string::const_iterator it = in.begin() ; it != in.end() ; it += 2 )
+  {
+    char first = *it;
+    char second = *(it + 1);
+    char binval;
+
+    if ( first >= '0' && first <= '9' )
+      binval = (first - '0') << 4;
+    else if (first >= 'A' && first <= 'F' )
+      binval = (first - 'A' + 10) << 4;
+    else if (first >= 'a' && first <= 'f' )
+      binval = (first - 'a' + 10) << 4;
+    else
+    {
+      // Invalid hex digit
+      result.clear();
+      return result;
+    }
+
+    if ( second >= '0' && second <= '9' )
+      binval += second - '0';
+    else if (second >= 'A' && second <= 'F' )
+      binval += second - 'A' + 10;
+    else if (second >= 'a' && second <= 'f' )
+      binval += second - 'a' + 10;
+    else
+    {
+      // Invalid hex digit
+      result.clear();
+      return result;
+    }
+
+    result += binval;
+  }
+
+  return result;
+}
+
 }

--- a/utils.hh
+++ b/utils.hh
@@ -37,6 +37,8 @@ std::string toHex( unsigned char const * in, unsigned size );
 
 std::string toHex( string const & );
 
+string fromHex( string const & in );
+
 template <typename T>
 string numberToString( T pNumber )
 {

--- a/zbackup.cc
+++ b/zbackup.cc
@@ -391,6 +391,19 @@ invalid_option:
       zbb.setPassword( passwords[ 1 ] );
     }
     else
+    if ( strcmp( args[ 0 ], "reindex" ) == 0 )
+    {
+      if ( args.size() != 2)
+      {
+        fprintf( stderr, "Usage: %s %s <storage path>\n",
+                 *argv, args[ 0 ] );
+        return EXIT_FAILURE;
+      }
+
+      ZIndexer zix( args[ 1 ], passwords[ 0 ], config );
+      zix.reindex();
+    }
+    else
     if ( strcmp( args[ 0 ], "inspect" ) == 0 )
     {
       if ( args.size() < 2 || args.size() > 3 )

--- a/zbackup.cc
+++ b/zbackup.cc
@@ -183,6 +183,7 @@ invalid_option:
 "            a valid (initialized) storage\n"
 "    inspect [fast|deep] <backup file name> - inspect backup (default\n"
 "            is fast)\n"
+"    reindex <storage path> - rebuilds an index of all bundles in the repository\n"
 "    gc [fast|deep] <storage path> - performs garbage\n"
 "            collection (default is fast)\n"
 "    passwd <storage path> - changes repo info file passphrase\n"

--- a/zutils.hh
+++ b/zutils.hh
@@ -77,6 +77,16 @@ public:
   void gc( bool );
 };
 
+class ZIndexer : public ZBackupBase
+{
+public:
+  ZIndexer( string const & storageDir, string const & password,
+            Config & configIn );
+
+  /// Rebuilds a single index from the bundles in the repository
+  void reindex();
+};
+
 class ZInspect : public ZBackupBase
 {
 public:


### PR DESCRIPTION
I had some trouble with garbage collection and my indexes, probably related to the issues fixed in https://github.com/zbackup/zbackup/pull/87. `gcConcat` mostly dealt with it, but the resulting index had duplicate entries for many bundles. So I wrote this code to rebuild the index from the bundles.
