### PR TITLE
Remove use_count() from the smart pointer

### DIFF
--- a/sptr.hh
+++ b/sptr.hh
@@ -67,9 +67,6 @@ public:
     }
   }
 
-  unsigned use_count() const
-  { return count; }
-
   sptr_base & operator = ( sptr_base const & other )
   { if ( &other != this ) { reset(); p = other.p; count = other.count; increment(); }
     return * this; }


### PR DESCRIPTION
- method is unused in the zbackup codebase
- returns the **pointer** when it should be returning the value
  it points to, e.g. , so that was wrong always.
  Causes build failures with modern C++ compilers (clang9
  for instance)

@davidbartonau your fork seems the most likely-of-continuations

