### PR TITLE
Require C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 # Copyright (c) 2012-2014 Konstantin Isakov <ikm@zbackup.org> and ZBackup contributors, see CONTRIBUTORS
 # Part of ZBackup. Licensed under GNU GPLv2 or later + OpenSSL, see LICENSE
 
-cmake_minimum_required( VERSION 2.8.3 )
-project( zbackup )
+cmake_minimum_required( VERSION 3.1 )
+project( zbackup LANGUAGES C CXX )
+
+set( CMAKE_CXX_STANDARD 11 )
+set( CMAKE_CXX_STANDARD_REQUIRED ON )
 
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 

--- a/sptr.hh
+++ b/sptr.hh
@@ -25,9 +25,9 @@ class sptr_base
 
 public:
 
-  sptr_base(): p( 0 ), count( 0 ) {}
+  sptr_base(): p( nullptr ), count( nullptr ) {}
 
-  sptr_base( T * p_ ): p( p_ ), count( p ? new unsigned( 1 ) : 0 )
+  sptr_base( T * p_ ): p( p_ ), count( p ? new unsigned( 1 ) : nullptr )
   {
   }
 
@@ -48,21 +48,21 @@ public:
       {
         delete count;
 
-        count = 0;
+        count = nullptr;
 
         if ( p )
         {
           T * p_ = p;
   
-          p = 0;
+          p = nullptr;
   
           delete p_;
         }
       }
       else
       {
-        p = 0;
-        count = 0;
+        p = nullptr;
+        count = nullptr;
       }
     }
   }


### PR DESCRIPTION
- Update CMake version to one that is still supported
- Bump C++ version to 11, since all current compilers support that
- Give sptr.hh the nullptr treatment (instead of 0 -- this is
  one of the nice things C++11 gives us)

(This is independent of fixing/removing `use_count()`)