### PR TITLE
CMake tidying

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 cmake_minimum_required( VERSION 2.8.3 )
 project( zbackup )
 
+option( WITH_BUSE "Enable userspace block devices" ON )
+
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 
 if( NOT CMAKE_BUILD_TYPE )
@@ -93,9 +95,16 @@ set( sourceFiles
   zbackup.cc
   zbackup_base.cc
   zutils.cc
-  buse.c
 )
+if ( WITH_BUSE )
+  list( APPEND sourceFiles
+    buse.c
+  )
+endif()
 add_executable( zbackup ${sourceFiles} ${protoSrcs} ${protoHdrs} )
+if ( WITH_BUSE )
+  target_compile_definitions( zbackup PRIVATE WITH_BUSE )
+endif()
 
 target_link_libraries( zbackup
   ${PROTOBUF_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,42 @@ if ( ZBACKUP_VERSION )
   MESSAGE("ZBackup version ${ZBACKUP_VERSION}")
 endif( ZBACKUP_VERSION )
 
-file( GLOB sourceFiles "*.cc" "*.c" )
+set( sourceFiles
+  appendallocator.cc
+  backup_collector.cc
+  backup_creator.cc
+  backup_file.cc
+  backup_restorer.cc
+  bundle.cc
+  chunk_id.cc
+  chunk_index.cc
+  chunk_storage.cc
+  compression.cc
+  config.cc
+  debug.cc
+  dir.cc
+  encrypted_file.cc
+  encryption.cc
+  encryption_key.cc
+  file.cc
+  index_file.cc
+  message.cc
+  mt.cc
+  objectcache.cc
+  page_size.cc
+  random.cc
+  rolling_hash.cc
+  sha256.cc
+  storage_info_file.cc
+  tmp_mgr.cc
+  unbuffered_file.cc
+  utils.cc
+  version.cc
+  zbackup.cc
+  zbackup_base.cc
+  zutils.cc
+  buse.c
+)
 add_executable( zbackup ${sourceFiles} ${protoSrcs} ${protoHdrs} )
 
 target_link_libraries( zbackup

--- a/zbackup.cc
+++ b/zbackup.cc
@@ -173,8 +173,10 @@ invalid_option:
 "    restore <backup file name> - restores a backup to stdout\n"
 "    restore <backup file name> <output file name> - restores\n"
 "            a backup to file using two-pass \"cacheless\" process\n"
+#ifdef WITH_BUSE
 "    nbd <backup file name> /dev/nbd0\n"
 "            start NBD server that will serve backup data as block device\n"
+#endif
 "    export <source storage path> <destination storage path> -\n"
 "            performs export from source to destination storage\n"
 "    import <source storage path> <destination storage path> -\n"
@@ -280,6 +282,7 @@ invalid_option:
         zr.restoreToStdin( args[ 1 ] );
     }
     else
+#ifdef WITH_BUSE
     if ( strcmp( args[ 0 ], "nbd" ) == 0 )
     {
       // Start NBD server
@@ -294,6 +297,7 @@ invalid_option:
       zr.startNBDServer( args[ 1 ], args[ 2 ] );
     }
     else
+#endif
     if ( strcmp( args[ 0 ], "export" ) == 0 || strcmp( args[ 0 ], "import" ) == 0 )
     {
       if ( args.size() != 3 )

--- a/zutils.cc
+++ b/zutils.cc
@@ -6,7 +6,11 @@
 #include "sha256.hh"
 #include "backup_collector.hh"
 #include "utils.hh"
+
+#ifdef WITH_BUSE
 #include "buse.h"
+#endif
+
 #include <unistd.h>
 
 using std::vector;
@@ -265,6 +269,7 @@ void ZRestore::restoreToStdin( string const & inputFileName )
     throw exChecksumError();
 }
 
+#ifdef WITH_BUSE
 static int buse_read(void *buf, u_int32_t len, u_int64_t offset, void *userdata)
 {
   dPrintf( "NBD read offset=%lu, size=%u\n", offset, len );
@@ -296,6 +301,7 @@ void ZRestore::startNBDServer( string const & inputFileName, string const & nbdD
 
   buse_main(nbdDevice.c_str(), &aop, (void *)&restorer);
 }
+#endif
 
 ZExchange::ZExchange( string const & srcStorageDir, string const & srcPassword,
                       string const & dstStorageDir, string const & dstPassword,

--- a/zutils.hh
+++ b/zutils.hh
@@ -46,8 +46,10 @@ public:
   /// Restores the data to stdout
   void restoreToStdin( string const & inputFileName );
 
+#ifdef WITH_BUSE
   /// Starts NBD server that serves backup data as block device with random access
   void startNBDServer( string const & inputFileName, string const & nbdDevice );
+#endif
 };
 
 class ZExchange


### PR DESCRIPTION
- expand the list of source files, following the note from the CMake documentation:
  > We do not recommend using GLOB to collect a list of source files from
  > your source tree.  If no CMakeLists.txt file changes when a source is
  > added or removed then the generated build system cannot know when to
  > ask CMake to regenerate.
- add a CMake-level option `WITH_BUSE` (default on) to determine whether BUSE / the NBD server is available. On FreeBSD, this code won't compile, so it's nice to be able to just turn it off.