### PR TITLE
Need unistd for unlink()

### DIFF
--- a/backup_collector.cc
+++ b/backup_collector.cc
@@ -3,6 +3,8 @@
 
 #include "backup_collector.hh"
 
+#include <unistd.h>
+
 using std::string;
 
 BundleCollector::BundleCollector( string const & bundlesPath,


### PR DESCRIPTION
Some .cc files already included `<unistd.h>`, but not this one. Linux system headers are more lenient that way.