### PR TITLE
use one parameter when calling SetTotalBytesLimit

### DIFF
--- a/backup_restorer.cc
+++ b/backup_restorer.cc
@@ -48,7 +48,7 @@ void restore( ChunkStorage::Reader & chunkStorageReader,
   // TODO: this disables size checks for each separate message. Figure a better
   // way to do this while keeping them enabled. It seems we need to create an
   // instance of CodedInputStream for each message, but it might be expensive
-  cis.SetTotalBytesLimit( backupData.size(), -1 );
+  cis.SetTotalBytesLimit( backupData.size() );
 
   // Used when emitting chunks
   string chunk;
@@ -150,7 +150,7 @@ public:
     // TODO: this disables size checks for each separate message. Figure a better
     // way to do this while keeping them enabled. It seems we need to create an
     // instance of CodedInputStream for each message, but it might be expensive
-    cis.SetTotalBytesLimit( backupData.size(), -1 );
+    cis.SetTotalBytesLimit( backupData.size() );
   }
 
   ~BackupInstructionsIterator()


### PR DESCRIPTION
Protobuf recently deprecated the second argument of `SetTotalBytesLimit`.