### PR TITLE
Backport #158 - use one param when calling SetTotalBytesLimit

### DIFF
--- a/backup_restorer.cc
+++ b/backup_restorer.cc
@@ -27,7 +27,7 @@ void restore( ChunkStorage::Reader & chunkStorageReader,
   // TODO: this disables size checks for each separate message. Figure a better
   // way to do this while keeping them enabled. It seems we need to create an
   // instance of CodedInputStream for each message, but it might be expensive
-  cis.SetTotalBytesLimit( backupData.size(), -1 );
+  cis.SetTotalBytesLimit( backupData.size() );
 
   // Used when emitting chunks
   string chunk;


### PR DESCRIPTION
Similar to #158 - but for the stable branch.